### PR TITLE
Clarify tutorial code with detailed comments

### DIFF
--- a/dummy_api/main.py
+++ b/dummy_api/main.py
@@ -3,15 +3,38 @@ from fastapi.security.api_key import APIKeyHeader
 from pydantic import BaseModel
 import os
 
+# ---------------------------------------------------------------------------
+#  Цей модуль демонструє створення невеликого REST API за допомогою FastAPI.
+#  Ми будуємо сервіс з двома ресурсами (users та items), який захищений
+#  простим механізмом авторизації "ключ в заголовку". Коментарі розписані
+#  максимально докладно, аби програмісти, що ніколи не працювали з FastAPI,
+#  зрозуміли кожен крок.
+# ---------------------------------------------------------------------------
+
+# === Налаштування авторизації =================================================
+# Назва HTTP-заголовка, в якому клієнт має передавати свій API‑ключ.
 API_KEY_NAME = "X-API-Key"
+
+# Об'єкт APIKeyHeader описує, як FastAPI має шукати ключ у запиті.
+#   - name: власне назва заголовка
+#   - auto_error=True означає, що якщо заголовка немає, автоматично буде
+#     згенерована помилка 403. Ми могли б поставити False і обробити її самостійно.
 api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=True)
 
+# === Ініціалізація FastAPI =====================================================
+# FastAPI створює об'єкт застосунку, який приймає вхідні HTTP‑запити і
+# повертає відповіді. Аргументи title/description/version потрапляють у
+# автоматично згенеровану OpenAPI-документацію (ендпоїнти /docs та /openapi.json).
 app = FastAPI(
     title="Dummy Product API",
     description="Фіктивний API з авторизацією X-API-Key. Перевірте /openapi.json та /docs.",
     version="1.0.0",
 )
 
+# === Моделі даних ==============================================================
+# Pydantic BaseModel дозволяє описувати структуру запитів/відповідей та
+# автоматично валідує дані. Класи нижче використовуються як схеми для
+# повернення інформації про користувача та товар.
 class UserInfo(BaseModel):
     user_id: str
     username: str
@@ -22,20 +45,30 @@ class Item(BaseModel):
     name: str
     description: str | None = None
 
+# === Функція перевірки ключа ===================================================
+# Security(...) запускає заздалегідь сконфігурований APIKeyHeader, дістає
+# значення ключа із заголовка запиту та передає його у параметр api_key.
+# Ми порівнюємо його з еталонним значенням із змінної середовища.
 async def get_api_key(api_key: str = Security(api_key_header)):
     expected = os.getenv("DUMMY_API_SECRET_KEY", "")
+    # Якщо ключ співпадає – повертаємо його, інакше повідомляємо про помилку
     if api_key and api_key == expected:
         return api_key
     raise HTTPException(status_code=403, detail="Could not validate credentials")
 
-
+# === Кореневий ендпоїнт ========================================================
+# Найпростіший маршрут, який дозволяє перевірити, що сервер працює.
 @app.get("/")
 def root():
     return {"message": "Welcome to Dummy API. See /docs or /openapi.json"}
 
-
+# === Ендпоїнт /users/{user_id} ==================================================
+# Декоратор @app.get створює HTTP GET маршрут. Параметр response_model
+# повідомляє FastAPI, що відповідь має відповідати схемі UserInfo.
+# Параметр tags додає ендпоїнт у відповідну групу в Swagger UI.
 @app.get("/users/{user_id}", response_model=UserInfo, tags=["Users"])
 async def get_user_info(user_id: str, api_key: str = Depends(get_api_key)):
+    # "База даних" користувачів – звичайний словник для прикладу
     users_db = {
         "user123": {"user_id": "user123", "username": "Alice", "roles": ["admin", "user"]},
         "user456": {"user_id": "user456", "username": "Bob", "roles": ["user"]},
@@ -44,7 +77,7 @@ async def get_user_info(user_id: str, api_key: str = Depends(get_api_key)):
         return users_db[user_id]
     raise HTTPException(status_code=404, detail="User not found")
 
-
+# === Ендпоїнт /items/{item_id} ==================================================
 @app.get("/items/{item_id}", response_model=Item, tags=["Items"])
 async def get_item_info(item_id: str, api_key: str = Depends(get_api_key)):
     items_db = {
@@ -55,7 +88,10 @@ async def get_item_info(item_id: str, api_key: str = Depends(get_api_key)):
         return items_db[item_id]
     raise HTTPException(status_code=404, detail="Item not found")
 
-
+# === Точка входу ===============================================================
+# Якщо цей файл запускати безпосередньо (python main.py),
+# ми піднімаємо веб-сервер Uvicorn. dotenv.load_dotenv() читає файл .env і
+# додає змінні середовища, зручні для локального тестування.
 if __name__ == "__main__":
     import uvicorn, dotenv
     dotenv.load_dotenv()

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -1,11 +1,21 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# ---------------------------------------------------------------------------
+#  Конфігураційний модуль. Pydantic Settings дозволяє описати всі потрібні
+#  змінні середовища в одному класі та автоматично зчитати їх з .env файлу.
+#  Це зручно, коли у проєкті потрібно передавати секретні ключі чи URL.
+# ---------------------------------------------------------------------------
+
 class Settings(BaseSettings):
+    # model_config вказує, де шукати файл зі змінними та як обробляти зайві поля.
     model_config = SettingsConfigDict(env_file='./.env', env_file_encoding='utf-8', extra='ignore')
 
+    # Ключ до OpenAI, URL до нашого Dummy API, секретний ключ для авторизації та
+    # шлях до бінарника, який перетворює OpenAPI на MCP-інструменти.
     OPENAI_API_KEY: str
     DUMMY_API_URL: str
     DUMMY_API_SECRET_KEY: str
     OPENAPI_MCP_BIN: str  # шлях до бинарника
 
+# Ініціалізуємо глобальний об'єкт settings, який можна імпортувати з інших модулів.
 settings = Settings()

--- a/mcp_server/crew_runtime.py
+++ b/mcp_server/crew_runtime.py
@@ -11,10 +11,24 @@ from .config import settings
 from .rag import build_or_load_retriever
 from .export_openapi import write_yaml_openapi
 
-# LLM (увімкнути справжній стрімінг можна stream=True)
+# ---------------------------------------------------------------------------
+#  Тут ми поєднуємо кілька складових:
+#    * RAG (retrieval-augmented generation) для підказок LLM;
+#    * MCP (Model Context Protocol), що автоматично перетворює OpenAPI-ендпоїнти
+#      на інструменти;
+#    * CrewAI – надбудова над LLM, яка дозволяє керувати агентами та задачами.
+#  Коментарі націлені на тих, хто вперше стикається з цими бібліотеками.
+# ---------------------------------------------------------------------------
+
+# === Ініціалізація LLM ========================================================
+# LLM – обгортка CrewAI, яка знає як викликати модель. Параметр stream=False
+# означає, що ми отримуватимемо весь текст одразу. Ключ до OpenAI беремо зі
+# змінних середовища (через Settings у config.py).
 llm = LLM(model="openai/gpt-4o-mini", stream=False, api_key=settings.OPENAI_API_KEY)
 
-# RAG як кастомний тул
+# === Налаштування RAG =========================================================
+# build_or_load_retriever() готує індекс із локальних текстових файлів і
+# повертає об'єкт, який може швидко знаходити релевантні документи.
 _retriever = build_or_load_retriever()
 
 @tool("RAG Search")
@@ -23,12 +37,17 @@ def rag_search(query: str) -> str:
     docs = _retriever.get_relevant_documents(query)
     return "\n\n".join([f"[{i+1}] {d.page_content}" for i, d in enumerate(docs)])
 
+# === Головна функція ==========================================================
+# run_with_mcp – точка, де ми збираємо все разом: завантажуємо OpenAPI,
+# піднімаємо MCP‑сервер, створюємо агента CrewAI з RAG та інструментами і
+# виконуємо задачу.
+
 def run_with_mcp(user_query: str, chat_history: list[tuple[str, str]], client_api_key: str) -> str:
     """
     Підключаємо MCP-сервер (OpenAPI -> інструменти), додаємо RAG і запускаємо Crew.
     Ключ клієнта передаємо в ENV змінній 'API_KEY' stdio-процесу MCP.
     """
-    # 1) Готуємо локальну YAML-спеку, якщо її ще немає
+    # 1) Переконуємось, що маємо локальну OpenAPI-специфікацію.
     openapi_path = "openapi.yaml"
     if not os.path.exists(openapi_path):
         spec_url = urljoin(settings.DUMMY_API_URL.rstrip("/") + "/", "openapi.json")
@@ -36,20 +55,23 @@ def run_with_mcp(user_query: str, chat_history: list[tuple[str, str]], client_ap
         resp.raise_for_status()
         write_yaml_openapi(resp.json(), Path(openapi_path))
 
-    # 2) Stdio-параметри MCP: додаємо --base-url (важливо для FastAPI)
+    # 2) Готуємо параметри запуску MCP у stdio-режимі. Тут ми передаємо
+    #    базову URL нашого Dummy API та API_KEY клієнта.
     serverparams = StdioServerParameters(
         command=settings.OPENAPI_MCP_BIN,
         args=["--base-url", settings.DUMMY_API_URL, openapi_path],
         env={"API_KEY": client_api_key},
     )
 
-    # 3) Піднімаємо MCP-адаптер та отримуємо інструменти
+    # 3) Піднімаємо MCP-адаптер, який прочитає OpenAPI та перетворить
+    #    кожен operationId на інструмент, доступний нашому агенту.
     mcp_adapter = MCPServerAdapter(serverparams)
     try:
-        mcp_tools = mcp_adapter.tools  # список MCP-інструментів із OpenAPI
+        mcp_tools = mcp_adapter.tools  # список інструментів із Dummy API
         tools = [rag_search] + mcp_tools
 
-        # 4) Агент CrewAI
+        # 4) Налаштовуємо агента CrewAI. Він отримує опис ролі, мети, бекграунду
+        #    та список інструментів, якими може користуватися.
         agent = Agent(
             role="MCP інтегрований асистент",
             goal=(
@@ -67,7 +89,7 @@ def run_with_mcp(user_query: str, chat_history: list[tuple[str, str]], client_ap
             verbose=True,
         )
 
-        # 5) Завдання з контекстом історії
+        # 5) Формуємо задачу (Task) з урахуванням попередньої історії чату.
         hist_text = "\n".join([f"{r.upper()}: {c}" for r, c in chat_history])
         task = Task(
             description=(
@@ -80,6 +102,7 @@ def run_with_mcp(user_query: str, chat_history: list[tuple[str, str]], client_ap
             agent=agent,
         )
 
+        # 6) Crew – контейнер, який запускає послідовність задач агентів.
         crew = Crew(
             agents=[agent],
             tasks=[task],
@@ -90,5 +113,5 @@ def run_with_mcp(user_query: str, chat_history: list[tuple[str, str]], client_ap
         result = crew.kickoff()
         return str(result)
     finally:
-        # закриваємо stdio-з’єднання з MCP
+        # 7) Завжди закриваємо підключення до MCP, щоб не залишати висячі процеси.
         mcp_adapter.stop()

--- a/mcp_server/export_openapi.py
+++ b/mcp_server/export_openapi.py
@@ -7,12 +7,21 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict
 
+# ---------------------------------------------------------------------------
+#  Невеликий модуль, що містить утиліти для запису OpenAPI-специфікації у
+#  різні формати. Ми використовуємо його в crew_runtime, щоб зберегти
+#  отриманий від Dummy API опис у локальний файл. Typer дозволяє легко
+#  створювати CLI, хоча тут ми використовуємо лише функції для експорту.
+# ---------------------------------------------------------------------------
 
 class OutputTypeEnum(str, Enum):
     json = "JSON"
     yaml = "YAML"
     both = "BOTH"
 
+# Функції нижче приймають словник з даними OpenAPI та шлях до файлу,
+# після чого зберігають його як JSON або YAML. Для простоти логування
+# використовується стандартний модуль logging.
 
 def write_json_openapi(openapi: Dict[str, Any], output_path: Path) -> None:
     logging.info(f"Writing OpenAPI to {str(output_path)}")

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -8,46 +8,66 @@ from .config import settings
 from .storage import add, history
 from .crew_runtime import run_with_mcp
 
+# ---------------------------------------------------------------------------
+#  Цей модуль запускає основний FastAPI-сервер, який інтегрує одразу кілька
+#  технологій: LLM через CrewAI, механізм RAG та інструменти MCP. Кожен запит
+#  від користувача обробляється послідовно, результати зберігаються в SQLite,
+#  а відповідь стрімиться символ за символом. Нижче докладно пояснено кожен
+#  крок – як у лекції для розробників, які вперше стикаються з цими бібліотеками.
+# ---------------------------------------------------------------------------
+
+# === Опис структури вхідного запиту ==========================================
+# Pydantic BaseModel описує тіло POST-запиту. Ми очікуємо ідентифікатор клієнта
+# (щоб зберігати історію) та текст повідомлення для LLM.
+class ChatRequest(BaseModel):
+    client_id: str
+    message: str
+
+# === Ініціалізація FastAPI ======================================================
 app = FastAPI(
     title="MCP + CrewAI Server",
     description="Приймає client_id, message; стрімить відповідь; зберігає історію; використовує RAG і MCP-інструменти.",
     version="1.0.0",
 )
 
-class ChatRequest(BaseModel):
-    client_id: str
-    message: str
-
+# === Основний ендпоїнт =========================================================
+# Клієнт надсилає POST /chat/stream з JSON-тілом ChatRequest і заголовком
+# X-API-Key, який буде передано далі в MCP-інструмент (авторизація до Dummy API).
 @app.post("/chat/stream")
 async def chat_stream(req: ChatRequest, x_api_key: str | None = Header(None)):
+    # 1) Перевіряємо, що ключ присутній. FastAPI автоматично зчитує заголовок
+    #    X-API-Key і передає його в параметр x_api_key.
     if not x_api_key:
         raise HTTPException(status_code=401, detail="X-API-Key header is required")
 
-    # Дістаємо історію
+    # 2) Витягуємо останні 20 повідомлень із бази, щоб підтримувати контекст.
     chat_hist = history(req.client_id, limit=20)
 
+    # 3) Запускаємо синхронну функцію run_with_mcp у пулі потоків.
     loop = asyncio.get_event_loop()
-
-    # Запускаємо CrewAI (синхронне kickoff) у thread pool
     result_text = await loop.run_in_executor(
         None,
-        run_with_mcp,
+        run_with_mcp,  # функція, що поєднує CrewAI + MCP
         req.message,
         chat_hist,
         x_api_key,
     )
 
+    # 4) Створюємо генератор, який "друкує" відповідь поступово.
     async def generator():
-        # Простий "typewriter": по літерах
+        # Виводимо відповідь по символах з невеликою затримкою, імітуючи набір тексту.
         for ch in result_text:
             yield ch
             await asyncio.sleep(0.005)
 
-        # Після завершення — зберігаємо історію
+        # Після завершення зберігаємо історію діалогу в базу даних.
         add(req.client_id, "user", req.message)
         add(req.client_id, "assistant", result_text)
 
+    # 5) Повертаємо StreamingResponse, щоб клієнт міг отримувати текст у реальному часі.
     return StreamingResponse(generator(), media_type="text/plain")
 
+# === Точка входу ===============================================================
 if __name__ == "__main__":
+    # Uvicorn – ASGI-сервер, який запускає наш FastAPI-додаток.
     uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/mcp_server/rag.py
+++ b/mcp_server/rag.py
@@ -5,10 +5,16 @@ from langchain_community.vectorstores import FAISS
 from pathlib import Path
 import os
 
+# ---------------------------------------------------------------------------
+#  У цьому файлі формується найпростіший RAG-ланцюжок. Ми беремо тексти з
+#  каталогу rag_documents, розбиваємо їх на шматочки, будуємо векторний
+#  індекс FAISS та повертаємо retriever, який може шукати релевантні фрагменти.
+# ---------------------------------------------------------------------------
+
 _DOCS_DIR = Path(__file__).parent / "rag_documents"
 _INDEX_PATH = Path(__file__).parent / ".faiss_index"
 
-# 1) Підготовка документів
+# 1) Завантаження документів з диску.
 def _load_docs():
     docs = []
     for p in _DOCS_DIR.glob("**/*.txt"):
@@ -16,19 +22,26 @@ def _load_docs():
         docs.extend(loader.load())
     return docs
 
-# 2) Створення/завантаження індексу
+# 2) Створення або відновлення індексу та повернення retriever'а.
 def build_or_load_retriever():
     from .config import settings
 
+    # CharacterTextSplitter ділить текст на перекривані шматки,
+    # щоб LLM отримував контекст, але не занадто великий.
     splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
     docs = splitter.split_documents(_load_docs())
+
+    # OpenAIEmbeddings перетворює текст на вектори за допомогою моделі OpenAI.
     embeddings = OpenAIEmbeddings(api_key=settings.OPENAI_API_KEY)  # використовує OPENAI_API_KEY з env
 
-    # Простий варіант: завжди перебудовуємо індекс у пам'яті
+    # Найпростіший варіант – перебудовуємо індекс щоразу в оперативній пам'яті.
     vectorstore = FAISS.from_documents(docs, embeddings)
     return vectorstore.as_retriever(search_kwargs={"k": 4})
 
-# Альтернатива (закоментовано): як перейти на Chroma або інший Vector DB
+# ---------------------------------------------------------------------------
+#  Альтернативний приклад (закоментовано): як перейти на Chroma або інший
+#  постійний Vector DB збереженням індексу на диску.
+# ---------------------------------------------------------------------------
 # from langchain_community.vectorstores import Chroma
 # def build_or_load_retriever():
 #     splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=100)

--- a/mcp_server/storage.py
+++ b/mcp_server/storage.py
@@ -2,8 +2,16 @@ import sqlite3
 from pathlib import Path
 from typing import Iterable, Tuple
 
+# ---------------------------------------------------------------------------
+#  Просте сховище історії повідомлень на SQLite. Ми зберігаємо кожне
+#  повідомлення (роль + текст) разом із client_id. Це дозволяє відновлювати
+#  контекст діалогу при наступних запитах.
+# ---------------------------------------------------------------------------
+
+# Шлях до файлу бази даних: лежить поруч із цим модулем.
 _DB = Path(__file__).parent / "chat.db"
 
+# Під час імпорту модуля створюємо таблицю, якщо її ще немає.
 def _init():
     with sqlite3.connect(_DB) as con:
         con.execute("""
@@ -16,15 +24,18 @@ def _init():
         )""")
 _init()
 
+# Додаємо нове повідомлення у базу.
 def add(client_id: str, role: str, content: str) -> None:
     with sqlite3.connect(_DB) as con:
         con.execute("INSERT INTO messages(client_id, role, content) VALUES(?,?,?)",
                     (client_id, role, content))
 
+# Повертаємо останні N повідомлень у вигляді [(role, content), ...]
 def history(client_id: str, limit: int = 20) -> list[Tuple[str,str]]:
     with sqlite3.connect(_DB) as con:
         rows = con.execute(
             "SELECT role, content FROM messages WHERE client_id=? ORDER BY id DESC LIMIT ?",
             (client_id, limit)
         ).fetchall()
+    # У SQLite вибірка йде в зворотному порядку, тому перевертаємо список.
     return list(reversed(rows))


### PR DESCRIPTION
## Summary
- explain how Dummy API uses FastAPI and API keys with step-by-step comments
- document main MCP server workflow, RAG pipeline, configuration and storage modules
- clarify OpenAPI export helpers and add instructional notes throughout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b9ba5aee88330aaab04f21ae09cf1